### PR TITLE
update mini pupper pid parameters so that it can stand

### DIFF
--- a/configs/mini_pupper_config/config/ros_control/ros_control.yaml
+++ b/configs/mini_pupper_config/config/ros_control/ros_control.yaml
@@ -25,23 +25,21 @@ joint_group_effort_controller:
       - rb1_rb2
       - rb2_rb3
     command_interfaces:
-    # https://github.com/rohitmenon86/ros2_controllers on galactic possible only with that fork
-    # https://github.com/ros-controls/ros2_controllers/pull/225
       - effort
     state_interfaces:
       - position
       - velocity
       
     gains:
-      base_lf1 : {p: 10.0, i: 0.0, d: 0.006}
-      lf1_lf2  : {p: 10.0, i: 0.0, d: 0.006}
-      lf2_lf3  : {p: 10.0, i: 0.0, d: 0.006}
-      base_rf1 : {p: 10.0, i: 0.0, d: 0.006}
-      rf1_rf2  : {p: 10.0, i: 0.0, d: 0.006}
-      rf2_rf3  : {p: 10.0, i: 0.0, d: 0.006}
-      base_lb1 : {p: 10.0, i: 0.0, d: 0.006}
-      lb1_lb2  : {p: 10.0, i: 0.0, d: 0.006}
-      lb2_lb3  : {p: 10.0, i: 0.0, d: 0.006}
-      base_rb1 : {p: 10.0, i: 0.0, d: 0.006}
-      rb1_rb2  : {p: 10.0, i: 0.0, d: 0.006}
-      rb2_rb3  : {p: 10.0, i: 0.0, d: 0.006}
+      base_lf1 : {p: 100.0, i: 0.0, d: 0.05}
+      lf1_lf2  : {p: 100.0, i: 0.0, d: 0.05}
+      lf2_lf3  : {p: 100.0, i: 0.0, d: 0.05}
+      base_rf1 : {p: 100.0, i: 0.0, d: 0.05}
+      rf1_rf2  : {p: 100.0, i: 0.0, d: 0.05}
+      rf2_rf3  : {p: 100.0, i: 0.0, d: 0.05}
+      base_lb1 : {p: 100.0, i: 0.0, d: 0.05}
+      lb1_lb2  : {p: 100.0, i: 0.0, d: 0.05}
+      lb2_lb3  : {p: 100.0, i: 0.0, d: 0.05}
+      base_rb1 : {p: 100.0, i: 0.0, d: 0.05}
+      rb1_rb2  : {p: 100.0, i: 0.0, d: 0.05}
+      rb2_rb3  : {p: 100.0, i: 0.0, d: 0.05}


### PR DESCRIPTION
Previously, Mini Pupper was not able to stand due to wrong PID parameters for ros control in ROS2 Humble. After this PR, Mini Pupper is able to stand. 

**Before change:**
![Screenshot from 2023-01-09 23-06-18](https://user-images.githubusercontent.com/2050002/211340024-14be830d-ae95-4867-9fad-785e94d29c97.png)


**After change:**

![Screenshot from 2023-01-08 23-27-23](https://user-images.githubusercontent.com/2050002/211205204-fdc97558-e06a-4069-95d2-06a8a17c9655.png)

I have spent 2-3 days with different parameters of PID, and current sets are the best in my experiments even through it's not perfect.
Mini pupper still cannot stand as stable as champ, might due to light weight. 